### PR TITLE
Correct URL for Nubiles network

### DIFF
--- a/Jellyfin.Plugin.PhoenixAdult/Sites/NetworkNubiles.cs
+++ b/Jellyfin.Plugin.PhoenixAdult/Sites/NetworkNubiles.cs
@@ -175,7 +175,7 @@ namespace PhoenixAdult.Sites
                 });
             }
 
-            var photoPageURL = "https://nubiles-porn.com/photo/gallery/" + sceneID[0];
+            var photoPageURL = "https://nubiles-porn.com/photoset/gallery" + sceneID[0];
             var photoPage = await HTML.ElementFromURL(photoPageURL, cancellationToken).ConfigureAwait(false);
             var sceneImages = photoPage.SelectNodesSafe("//div[@class='img-wrapper']//source[1]");
             foreach (var sceneImage in sceneImages)


### PR DESCRIPTION
I have troubles with Jellyfin recognizing a scene via PhoenixAdult ; here is the relevant part of the log:

> [2024-03-15 21:22:30.396 +01:00] [INF] [62] PhoenixAdult.Plugin: searchInfo.Name: Bad Teens Punished - 2016-06-08 - Naughty Teen Punished - S1:E8 - Lucy Doll
> [2024-03-15 21:22:30.399 +01:00] [INF] [62] PhoenixAdult.Plugin: site: 30:3 (BadTeensPunished)
> [2024-03-15 21:22:30.399 +01:00] [INF] [62] PhoenixAdult.Plugin: searchTitle: Naughty Teen Punished S1 E8 Lucy Doll
> [2024-03-15 21:22:30.399 +01:00] [INF] [62] PhoenixAdult.Plugin: searchDate: 2016-06-08
> [2024-03-15 21:22:30.399 +01:00] [INF] [62] PhoenixAdult.Plugin: provider: PhoenixAdult.Sites.NetworkNubiles
> [2024-03-15 21:22:30.405 +01:00] [ERR] [62] PhoenixAdult.Plugin: Request error: Name does not resolve (nubiles-porn.com:443)
> [2024-03-15 21:22:30.605 +01:00] [ERR] [43] Jellyfin.Drawing.Skia.SkiaEncoder: Unable to determine image dimensions for "/var/db/jellyfin/metadata/library

Because PA does not recognize it, Jellyfin ends up not displaying at all the video.

I traced it back to a wrong URL, which is now correct in this PR.