### PR TITLE
Hotfix for scene ID on pornhub

### DIFF
--- a/Jellyfin.Plugin.PhoenixAdult/Sites/SitePornhub.cs
+++ b/Jellyfin.Plugin.PhoenixAdult/Sites/SitePornhub.cs
@@ -26,7 +26,19 @@ namespace PhoenixAdult.Sites
                 return result;
             }
 
-            if ((searchTitle.StartsWith("ph", StringComparison.OrdinalIgnoreCase) || int.TryParse(searchTitle, out _)) && !searchTitle.Contains(' ', StringComparison.OrdinalIgnoreCase))
+            # Works with all IDs but sometimes does not work when you use both non-ph IDs and names
+            if ((searchTitle.StartsWith("ph", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("1", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("2", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("3", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("4", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("5", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("6", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("7", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("8", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("9", StringComparison.OrdinalIgnoreCase)
+                    || searchTitle.StartsWith("0", StringComparison.OrdinalIgnoreCase)
+                    || int.TryParse(searchTitle, out _)) && !searchTitle.Contains(' ', StringComparison.OrdinalIgnoreCase))
             {
                 var sceneURL = new Uri(Helper.GetSearchBaseURL(siteNum) + $"/view_video.php?viewkey={searchTitle}");
                 var sceneID = new string[] { Helper.Encode(sceneURL.PathAndQuery) };


### PR DESCRIPTION
Resolves #237

Not entirely sure how to get it to completely work.

I changed modified the if statement and it works seems to works but not for every video
```
if ((searchTitle.StartsWith("ph", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("1", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("2", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("3", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("4", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("5", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("6", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("7", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("8", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("9", StringComparison.OrdinalIgnoreCase)
    || searchTitle.StartsWith("0", StringComparison.OrdinalIgnoreCase)
    || int.TryParse(searchTitle, out _)) && !searchTitle.Contains(' ', StringComparison.OrdinalIgnoreCase))
```

I tested with theses
1. https://www.pornhub.com/view_video.php?viewkey=ph5cbc81da999fb
2. https://www.pornhub.com/view_video.php?viewkey=65ac0f44b2fcc
3. https://www.pornhub.com/view_video.php?viewkey=649bf79ec834f
4. https://www.pornhub.com/view_video.php?viewkey=64090a225ac72
5. https://www.pornhub.com/view_video.php?viewkey=ph629e050d45351
6. https://www.pornhub.com/view_video.php?viewkey=64cb037177901

Used the following file name styles

1. `Pornhub - ID - Name.ext`
2. `Pornhub - Name.ext` 
3. `Pornhub - ID.ext`

With the only exception of only the 6th video while using `Pornhub - ID - Name.ext` all worked.
